### PR TITLE
fix(DBS-1682): DBS-1682 expose Delivery.Timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,8 @@
+build:
+	./hack/buildall.sh
+
 test:
+	./hack/testall.sh
+
+coverage:
 	./hack/check.sh

--- a/amqp.go
+++ b/amqp.go
@@ -6,6 +6,7 @@ import "time"
 
 type (
 	// Option is a map of AMQP configurations
+	// amqp091 calls this amqp.Table, same map definition
 	Option map[string]interface{}
 
 	// Conn is the amqp connection interface

--- a/amqp/delivery.go
+++ b/amqp/delivery.go
@@ -7,6 +7,7 @@ import (
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
+// pointer to rabbitmq Delivery, so can change the fields into methods
 type Delivery struct {
 	*amqp.Delivery
 }

--- a/amqp/delivery.go
+++ b/amqp/delivery.go
@@ -32,7 +32,7 @@ func (d *Delivery) MessageId() string {
 }
 
 func (d *Delivery) Timestamp() time.Time {
-	return time.Now()
+	return d.Delivery.Timestamp
 }
 
 func (d *Delivery) ContentType() string {

--- a/amqp_test.go
+++ b/amqp_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bluearchive/generic_cache_wabbit"
 	"github.com/bluearchive/generic_cache_wabbit/amqptest"
 	"github.com/bluearchive/generic_cache_wabbit/amqptest/server"
 )
@@ -222,7 +223,18 @@ func sub(conn wabbit.Conn, t *testing.T, done chan bool, bindDone chan bool) {
 	deliveryDone = make(chan bool)
 
 	go func() {
+		pauseMs := time.Duration(5 * time.Millisecond)
+		time.Sleep(pauseMs)
+		now := time.Now()
+
 		msg1 := <-deliveries
+
+		// check that the message timestamp is the publish time, not time.Now() as originally implemented
+		if now.Sub(msg1.Timestamp()) < pauseMs {
+			t.Errorf("Expected timestamp to be older than current time: %v now %v", msg1.Timestamp(), now)
+			deliveryDone <- true
+			return
+		}
 
 		if string(msg1.Body()) != "msg1" {
 			t.Errorf("Unexpected message: %s", string(msg1.Body()))

--- a/amqp_test.go
+++ b/amqp_test.go
@@ -223,7 +223,7 @@ func sub(conn wabbit.Conn, t *testing.T, done chan bool, bindDone chan bool) {
 	deliveryDone = make(chan bool)
 
 	go func() {
-		pauseMs := time.Duration(5 * time.Millisecond)
+		pauseMs := time.Duration(100 * time.Millisecond)
 		time.Sleep(pauseMs)
 		now := time.Now()
 

--- a/amqptest/dial_test.go
+++ b/amqptest/dial_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	wabbit "github.com/bluearchive/generic_cache_wabbit"
 	"github.com/bluearchive/generic_cache_wabbit/amqptest/server"
 	"github.com/pborman/uuid"
 )

--- a/amqptest/server/channel.go
+++ b/amqptest/server/channel.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/bluearchive/generic_cache_wabbit"
 	"github.com/bluearchive/generic_cache_wabbit/utils"
@@ -114,6 +115,7 @@ func (ch *Channel) Publish(exc, route string, msg []byte, opt wabbit.Option) err
 		wabbit.Option(hdrs),
 		contentType,
 		route,
+		time.Now(),
 	)
 
 	err := ch.VHost.Publish(exc, route, d, nil)
@@ -174,7 +176,7 @@ func (ch *Channel) Consume(queue, consumerName string, _ wabbit.Option) (<-chan 
 				// since we keep track of unacked messages for
 				// the channel, we need to rebind the delivery
 				// to the consumer channel.
-				d = NewDelivery(ch, d.Body(), d.DeliveryTag(), d.MessageId(), d.Headers(), d.ContentType(), d.RoutingKey())
+				d = NewDelivery(ch, d.Body(), d.DeliveryTag(), d.MessageId(), d.Headers(), d.ContentType(), d.RoutingKey(), d.Timestamp())
 
 				ch.addUnacked(d, q)
 

--- a/amqptest/server/channel_test.go
+++ b/amqptest/server/channel_test.go
@@ -319,7 +319,7 @@ func TestAckedMessagesAreCommited(t *testing.T) {
 	go func() {
 		data := <-deliveries2
 
-		t.Errorf("Data ack'ed delivered again: %s", string(data.Body()))
+		t.Errorf("Data ack'ed delivered again: %d: %s", data.DeliveryTag(), string(data.Body()))
 
 		panic("never reach here. Message was ack'ed")
 	}()

--- a/amqptest/server/delivery.go
+++ b/amqptest/server/delivery.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/bluearchive/generic_cache_wabbit"
+	amqp "github.com/bluearchive/generic_cache_wabbit/amqp"
+	amqp091 "github.com/rabbitmq/amqp091-go"
 )
 
 type (
@@ -18,10 +20,21 @@ type (
 		channel       *Channel
 		contentType   string
 		timestamp     time.Time
+		delivery      *amqp.Delivery
 	}
 )
 
 func NewDelivery(ch *Channel, data []byte, tag uint64, messageId string, hdrs wabbit.Option, contentType string, route string, timestamp time.Time) *Delivery {
+	d := amqp091.Delivery{
+		// Acknowledger: ch,
+		Body:        data,
+		DeliveryTag: tag,
+		MessageId:   messageId,
+		ContentType: contentType,
+		RoutingKey:  route,
+		Timestamp:   timestamp,
+	}
+	d2 := amqp.Delivery{&d}
 	return &Delivery{
 		data:          data,
 		headers:       hdrs,
@@ -31,6 +44,7 @@ func NewDelivery(ch *Channel, data []byte, tag uint64, messageId string, hdrs wa
 		contentType:   contentType,
 		originalRoute: route,
 		timestamp:     timestamp,
+		delivery:      &d2,
 	}
 }
 
@@ -47,7 +61,7 @@ func (d *Delivery) Reject(requeue bool) error {
 }
 
 func (d *Delivery) Body() []byte {
-	return d.data
+	return d.delivery.Body()
 }
 
 func (d *Delivery) Headers() wabbit.Option {

--- a/amqptest/server/delivery.go
+++ b/amqptest/server/delivery.go
@@ -10,7 +10,6 @@ import (
 
 type (
 	// Delivery is an interface to delivered messages
-	// FIXME: this shadows the actual Delivery in amqp/delivery.go, thus not testing its calls
 	Delivery struct {
 		data          []byte
 		headers       wabbit.Option

--- a/amqptest/server/delivery.go
+++ b/amqptest/server/delivery.go
@@ -10,6 +10,7 @@ import (
 
 type (
 	// Delivery is an interface to delivered messages
+	// FIXME: this shadows the actual Delivery in amqp/delivery.go, thus not testing its calls
 	Delivery struct {
 		data          []byte
 		headers       wabbit.Option
@@ -25,17 +26,26 @@ type (
 )
 
 func NewDelivery(ch *Channel, data []byte, tag uint64, messageId string, hdrs wabbit.Option, contentType string, route string, timestamp time.Time) *Delivery {
+	// amqp Delivery object
 	d := amqp091.Delivery{
-		// Acknowledger: ch,
-		Body:        data,
-		DeliveryTag: tag,
-		MessageId:   messageId,
+		Acknowledger: ch,
+		Headers:     amqp091.Table(hdrs),
 		ContentType: contentType,
-		RoutingKey:  route,
+		MessageId:   messageId,
 		Timestamp:   timestamp,
+		// valid on Consume only:
+		ConsumerTag: "",
+		// valid on Get only:
+		DeliveryTag: tag,
+		RoutingKey:  route,
+		Body:        data,
 	}
+	// wabbit Delivery wrappers the amqp object
 	d2 := amqp.Delivery{&d}
-	return &Delivery{
+
+	// return a test Delivery object that delegates all its methods to the actual
+	d3 := &Delivery{
+		// some tests depend on the fields of this mock, so leave them for now
 		data:          data,
 		headers:       hdrs,
 		channel:       ch,
@@ -46,18 +56,19 @@ func NewDelivery(ch *Channel, data []byte, tag uint64, messageId string, hdrs wa
 		timestamp:     timestamp,
 		delivery:      &d2,
 	}
+	return d3;
 }
 
 func (d *Delivery) Ack(multiple bool) error {
-	return d.channel.Ack(d.tag, multiple)
+	return d.delivery.Acknowledger.Ack(d.delivery.DeliveryTag(), multiple)
 }
 
 func (d *Delivery) Nack(multiple, requeue bool) error {
-	return d.channel.Nack(d.tag, multiple, requeue)
+	return d.delivery.Acknowledger.Nack(d.delivery.DeliveryTag(), multiple, requeue)
 }
 
 func (d *Delivery) Reject(requeue bool) error {
-	return d.channel.Nack(d.tag, false, requeue)
+	return d.delivery.Acknowledger.Nack(d.delivery.DeliveryTag(), false, requeue)
 }
 
 func (d *Delivery) Body() []byte {
@@ -65,29 +76,29 @@ func (d *Delivery) Body() []byte {
 }
 
 func (d *Delivery) Headers() wabbit.Option {
-	return d.headers
+	return wabbit.Option(d.delivery.Headers())
 }
 
 func (d *Delivery) DeliveryTag() uint64 {
-	return d.tag
+	return d.delivery.DeliveryTag()
 }
 
 func (d *Delivery) ConsumerTag() string {
-	return d.consumerTag
+	return d.delivery.ConsumerTag()
 }
 
 func (d *Delivery) MessageId() string {
-	return d.messageId
+	return d.delivery.MessageId()
 }
 
 func (d *Delivery) Timestamp() time.Time {
-	return d.timestamp
+	return d.delivery.Timestamp()
 }
 
 func (d *Delivery) ContentType() string {
-	return d.contentType
+	return d.delivery.ContentType()
 }
 
 func (d *Delivery) RoutingKey() string {
-	return d.originalRoute
+	return d.delivery.RoutingKey()
 }

--- a/amqptest/server/delivery.go
+++ b/amqptest/server/delivery.go
@@ -17,10 +17,11 @@ type (
 		messageId     string
 		channel       *Channel
 		contentType   string
+		timestamp     time.Time
 	}
 )
 
-func NewDelivery(ch *Channel, data []byte, tag uint64, messageId string, hdrs wabbit.Option, contentType string, route string) *Delivery {
+func NewDelivery(ch *Channel, data []byte, tag uint64, messageId string, hdrs wabbit.Option, contentType string, route string, timestamp time.Time) *Delivery {
 	return &Delivery{
 		data:          data,
 		headers:       hdrs,
@@ -29,6 +30,7 @@ func NewDelivery(ch *Channel, data []byte, tag uint64, messageId string, hdrs wa
 		messageId:     messageId,
 		contentType:   contentType,
 		originalRoute: route,
+		timestamp:     timestamp,
 	}
 }
 
@@ -65,7 +67,7 @@ func (d *Delivery) MessageId() string {
 }
 
 func (d *Delivery) Timestamp() time.Time {
-	return time.Now()
+	return d.timestamp
 }
 
 func (d *Delivery) ContentType() string {

--- a/amqptest/server/delivery.go
+++ b/amqptest/server/delivery.go
@@ -25,7 +25,7 @@ type (
 )
 
 func NewDelivery(ch *Channel, data []byte, tag uint64, messageId string, hdrs wabbit.Option, contentType string, route string, timestamp time.Time) *Delivery {
-	// amqp Delivery object
+	// amqp091 Delivery object from rabbitmq
 	d := amqp091.Delivery{
 		Acknowledger: ch,
 		Headers:     amqp091.Table(hdrs),
@@ -39,10 +39,10 @@ func NewDelivery(ch *Channel, data []byte, tag uint64, messageId string, hdrs wa
 		RoutingKey:  route,
 		Body:        data,
 	}
-	// wabbit Delivery wrappers the amqp object
+	// wabbit Delivery wrappers the amqp091 object
 	d2 := amqp.Delivery{&d}
 
-	// return a test Delivery object that delegates all its methods to the actual
+	// return a test Delivery object that delegates all its methods to the rabbitmq delivery
 	d3 := &Delivery{
 		// some tests depend on the fields of this mock, so leave them for now
 		data:          data,
@@ -75,7 +75,11 @@ func (d *Delivery) Body() []byte {
 }
 
 func (d *Delivery) Headers() wabbit.Option {
-	return wabbit.Option(d.delivery.Headers())
+	return d.headers
+	// FIXME: do not delegate the headers to amqp091, use the headers from the mock,
+	// server/utils sometimes segfaults with the real d.Headers()
+	// Note that this only affects the test server, generic_cache does not call Headers.
+	// return wabbit.Option(d.delivery.Headers())
 }
 
 func (d *Delivery) DeliveryTag() uint64 {

--- a/amqptest/server/utils.go
+++ b/amqptest/server/utils.go
@@ -104,7 +104,6 @@ func headersMatch(b *BindingsMap, d *Delivery) (bool, error) {
 		if !strings.HasPrefix(key, "x-") {
 			switch cmpType {
 			case "any":
-				// FIXME: this test sometimes segfaults if using d.Headers()
 				if d.headers[key] == val {
 					return true, nil
 				}

--- a/amqptest/server/utils.go
+++ b/amqptest/server/utils.go
@@ -104,7 +104,7 @@ func headersMatch(b *BindingsMap, d *Delivery) (bool, error) {
 		if !strings.HasPrefix(key, "x-") {
 			switch cmpType {
 			case "any":
-				// FIXME: this test sometimes segfaults if using Headers()
+				// FIXME: this test sometimes segfaults if using d.Headers()
 				if d.headers[key] == val {
 					return true, nil
 				}

--- a/amqptest/server/utils.go
+++ b/amqptest/server/utils.go
@@ -104,6 +104,7 @@ func headersMatch(b *BindingsMap, d *Delivery) (bool, error) {
 		if !strings.HasPrefix(key, "x-") {
 			switch cmpType {
 			case "any":
+				// FIXME: this test sometimes segfaults if using Headers()
 				if d.headers[key] == val {
 					return true, nil
 				}

--- a/amqptest/server/vhost_test.go
+++ b/amqptest/server/vhost_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"testing"
+	"time"
 
 	"github.com/bluearchive/generic_cache_wabbit"
 )
@@ -117,7 +118,7 @@ func TestQueueBind(t *testing.T) {
 		return
 	}
 
-	err = nwExchange.route("process.data", NewDelivery(&Channel{}, []byte{}, 1, "", wabbit.Option{}, ""))
+	err = nwExchange.route("process.data", NewDelivery(&Channel{}, []byte{}, 1, "", wabbit.Option{}, "", "", time.Now()))
 
 	if err != nil {
 		t.Error(err)
@@ -154,7 +155,7 @@ func TestBasicPublish(t *testing.T) {
 		return
 	}
 
-	err = vh.Publish("neoway", "process.data", NewDelivery(&Channel{}, []byte("teste"), 1, "", wabbit.Option{}, ""), nil)
+	err = vh.Publish("neoway", "process.data", NewDelivery(&Channel{}, []byte("teste"), 1, "", wabbit.Option{}, "", "", time.Now()), nil)
 
 	if err != nil {
 		t.Error(err)

--- a/hack/buildall.sh
+++ b/hack/buildall.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+for dir in `find . -name '*.go' | sed -e 's/[/][a-z_]*.go$//' | sort | uniq | grep -v examples`
+do
+  echo "====[ $dir ]================================================================"
+  go build
+done

--- a/hack/testall.sh
+++ b/hack/testall.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+for dir in `find . -name '*.go' | sed -e 's/[/][a-z_]*.go$//' | sort | uniq | grep -v examples`
+do
+  echo "====[ $dir ]================================================================"
+  go test -v $dir/ || break
+done


### PR DESCRIPTION
The new gdbcache code uses the wabbit wrapper not the amqp091-go library
- The wrapper does did not expose the Timestamp property of delivered messages.
- The wrapper had broken tests and no way to run all all tests, added a Makefile target.

NOTE: the change is a one-liner, Timestamp() now returns the message timestamp instead of time.Now()
NOTE: the other changes are to make the unit tests run